### PR TITLE
Modify the percentage display for Tracker docker implementation

### DIFF
--- a/lib/Cake/Console/Helper/ProgressShellHelper.php
+++ b/lib/Cake/Console/Helper/ProgressShellHelper.php
@@ -103,7 +103,7 @@ class ProgressShellHelper extends BaseShellHelper {
  *
  * @return void
  */
-	public function draw() {
+	public function draw($logged_percentage = 0) {
 		$numberLen = strlen(' 100%');
 		$complete = round($this->_progress / $this->_total, 2);
 		$barLen = ($this->_width - $numberLen) * ($this->_progress / $this->_total);
@@ -115,8 +115,11 @@ class ProgressShellHelper extends BaseShellHelper {
 		if ($pad > 0) {
 			$bar .= str_repeat(' ', $pad);
 		}
-		$percent = ($complete * 100) . '%';
-		$bar .= str_pad($percent, $numberLen, ' ', STR_PAD_LEFT);
-		$this->_consoleOutput->overwrite($bar, 0);
+		$percent = ($complete * 100);
+		$bar .= str_pad($percent . '%', $numberLen, ' ', STR_PAD_LEFT);
+		if ($percent % 10 === 0 && $percent !== $logged_percentage) {
+			CakeLog::write('debug', $bar);
+		}
+		return $percent;
 	}
 }


### PR DESCRIPTION
<!---
Modify the `draw()` Progress Helper class so it would write the progress into the tracker log in docker, as the Mcap parser is no longer running on consoles. Please note that this function can be easily replicated and have it inside the Mcap Parser instead so we don't have to make any changes to this repo. Please let me know your guys preferences.

-->
